### PR TITLE
Add dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+version: 2
+updates:
+  - package-ecosystem: bundler
+    directories:
+      - "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+      - ruby
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - DevOps
+      - dependencies
+      - github_actions


### PR DESCRIPTION
Context
Enable dependabot to open PRs on security updates.

Changes proposed in this pull request:
- Open PRs for ruby dependencies
- Open PRs for github action dependencies